### PR TITLE
Delimiter can be empty

### DIFF
--- a/lib/router-base.js
+++ b/lib/router-base.js
@@ -368,6 +368,7 @@
             requirements = route.requirements,
             _this = this;
         generatedPath = path.replace(this._paramsReplaceRegExp, function (match, delimiter, parameterName) {
+            delimiter = delimiter || '';
             var optional = parameterName in defaults,
                 exists = params && parameterName in params;
             if (exists) {


### PR DESCRIPTION
According regexp for params replace, delimiter can be undefined, so it must have default value. Otherwise
```js
generate('blah', {name: 'name'})
```
for
```yml
- id blah
  path /asd{name}qwe
```
returns `/asdundefinednameqwe`